### PR TITLE
[space-invaders]: check for all collisions possible

### DIFF
--- a/space_invaders/src/alien.cpp
+++ b/space_invaders/src/alien.cpp
@@ -42,6 +42,17 @@ alienType Alien::GetType()
     return type;
 }
 
+Rectangle Alien::GetRect()
+{
+    Rectangle rect;
+    rect.x = position.x;
+    rect.y = position.y;
+    rect.width = float(alienImages[type].width);
+    rect.height = float(alienImages[type].height);
+
+    return rect;
+}
+
 void Alien::UnloadImages()
 {
     for(unsigned int i = 0; i < ALIEN_TYPE_MAX; ++i)

--- a/space_invaders/src/alien.hpp
+++ b/space_invaders/src/alien.hpp
@@ -30,6 +30,7 @@ class Alien
         void Update(int direction);
         void Draw();
         alienType GetType();
+        Rectangle GetRect();
 
         static void UnloadImages();
 

--- a/space_invaders/src/block.cpp
+++ b/space_invaders/src/block.cpp
@@ -11,3 +11,14 @@ void Block::Draw()
 {
     DrawRectangle(position.x, position.y, BLOCK_WIDTH, BLOCK_HEIGHT, BLOCK_COLOR_ACTIVE);
 }
+
+Rectangle Block::GetRect()
+{
+    Rectangle rect;
+    rect.x = position.x;
+    rect.y = position.y;
+    rect.width = BLOCK_WIDTH;
+    rect.height = BLOCK_HEIGHT;
+
+    return rect;
+}

--- a/space_invaders/src/block.hpp
+++ b/space_invaders/src/block.hpp
@@ -10,6 +10,7 @@ class Block
     public:
         Block(Vector2 position);
         void Draw();
+        Rectangle GetRect();
 
     private:
         Vector2 position;

--- a/space_invaders/src/game.cpp
+++ b/space_invaders/src/game.cpp
@@ -7,7 +7,7 @@ Game::Game()
     CreateObstacles(4);
 
     // Create aliens
-    CreateAliens(2, 5);
+    CreateAliens(11, 5);
     aliensDirection = ALIEN_ARMY_HORIZONTAL_DIRECTION;
     lastFireTimeAlien = 0.0;
 
@@ -86,6 +86,9 @@ void Game::Update()
             mysteryShipSpawnInterval = GetRandomValue(MYSTERY_SHIP_MIN_SPAWN_INTERVAL, MYSTERY_SHIP_MAX_SPAWN_INTERVAL);
         }
     }
+
+    // Check for collisions
+    CheckCollisions();
 }
 
 void Game::HandleInput()
@@ -235,5 +238,120 @@ void Game::AlienShootLaser()
                                                 shooting_alien.position.y + shooting_alien.alienImages[shooting_alien.type].height},
                                                 LASER_BEAM_ALIEN_SPEED));
         lastFireTimeAlien = GetTime();
+    }
+}
+
+void Game::CheckCollisions()
+{
+    // Collisions between spaceship lasers and other elements
+    for(auto& spaceship_laser: spaceship.lasers)
+    {
+        // Collisions between spaceship lasers and aliens
+        auto it = aliens.begin();
+        while (it != aliens.end())
+        {
+            if(CheckCollisionRecs(spaceship_laser.GetRect(), it->GetRect()))
+            {
+                // There is a collision between a spaceship laser and an alien
+                it = aliens.erase(it); // Remove the alien from the vector
+                spaceship_laser.active = false;
+                std::cout << "Alien hit!" << std::endl;
+            }
+            else
+            {
+                ++it;
+            }
+        }
+
+        // Collisions between spaceship lasers and obstacles
+        for(auto& this_obstacle: obstacles)
+        {
+            auto it = this_obstacle.blocks.begin();
+            while(it != this_obstacle.blocks.end())
+            {
+                if(CheckCollisionRecs(spaceship_laser.GetRect(), it->GetRect()))
+                {
+                    // There is a collision between a spaceship laser and an obstacle block
+                    it = this_obstacle.blocks.erase(it); // Remove the block from the vector
+                    spaceship_laser.active = false;
+                    std::cout << "Obstacle damage!" << std::endl;
+                }
+                else
+                {
+                    ++it;
+                }
+            }
+        }
+
+        // Collisions between spaceship lasers and mystery ship
+        if(CheckCollisionRecs(spaceship_laser.GetRect(), mysteryShip.GetRect()))
+        {
+            // There is a collision between a spaceship laser and the mystery ship
+            mysteryShip.alive = false;
+            spaceship_laser.active = false;
+            std::cout << "Mystery ship hit!" << std::endl;
+        }
+    }
+
+    // Collisions between aliens lasers and other elements
+    for(auto& alien_laser: aliensLasers)
+    {
+        // Collisions between alien lasers and the spaceship
+        if(CheckCollisionRecs(alien_laser.GetRect(), spaceship.GetRect()))
+        {
+            // There is a collision between an alien laser and the spaceship
+            alien_laser.active = false;
+            std::cout << "Spaceship hit!" << std::endl;
+        }
+
+        // Collisions between alien lasers and obstacles
+        for(auto& this_obstacle: obstacles)
+        {
+            auto it = this_obstacle.blocks.begin();
+            while(it != this_obstacle.blocks.end())
+            {
+                if(CheckCollisionRecs(alien_laser.GetRect(), it->GetRect()))
+                {
+                    // There is a collision between an alien laser and an obstacle block
+                    it = this_obstacle.blocks.erase(it); // Remove the block from the vector
+                    alien_laser.active = false;
+                    std::cout << "Obstacle damage!" << std::endl;
+                }
+                else
+                {
+                    ++it;
+                }
+            }
+        }
+    }
+
+    // Collisions between aliens and other elements
+    for(auto& this_alien: aliens)
+    {
+        // Collision between aliens and the spaceship
+        if(CheckCollisionRecs(this_alien.GetRect(), spaceship.GetRect()))
+        {
+            // There is a collision between an alien and the spaceship
+            std::cout << "Spaceship hit by alien!" << std::endl;
+        }
+
+        // Collisions between aliens and obstacles
+        for(auto& this_obstacle: obstacles)
+        {
+            auto it = this_obstacle.blocks.begin();
+            while(it != this_obstacle.blocks.end())
+            {
+                if(CheckCollisionRecs(this_alien.GetRect(), it->GetRect()))
+                {
+                    // There is a collision between an alien and an obstacle block
+                    it = this_obstacle.blocks.erase(it); // Remove the block from the vector
+                    std::cout << "Obstacle damage by alien!" << std::endl;
+                }
+                else
+                {
+                    ++it;
+                }
+            }
+        }
     }
 }

--- a/space_invaders/src/game.hpp
+++ b/space_invaders/src/game.hpp
@@ -21,6 +21,7 @@ class Game
         void MoveAliens();
         void MoveAliensVertical(unsigned int distance);
         void AlienShootLaser();
+        void CheckCollisions();
 
         Spaceship spaceship;
         std::vector<Obstacle> obstacles;

--- a/space_invaders/src/laser.cpp
+++ b/space_invaders/src/laser.cpp
@@ -21,7 +21,6 @@ void Laser::Update()
         if( (position.y > GetScreenHeight()) || (position.y < 0) )
         {
             active = false;
-            std::cout << "Laser deactivated" << std::endl;
         }
     }
 }
@@ -32,4 +31,15 @@ void Laser::Draw()
     {
         DrawRectangle(position.x, position.y, LASER_BEAM_WIDTH, LASER_BEAM_HEIGTH, LASER_BEAM_COLOR);
     }
+}
+
+Rectangle Laser::GetRect()
+{
+    Rectangle rect;
+    rect.x = position.x;
+    rect.y = position.y;
+    rect.width = LASER_BEAM_WIDTH;
+    rect.height = LASER_BEAM_HEIGTH;
+
+    return rect;
 }

--- a/space_invaders/src/laser.hpp
+++ b/space_invaders/src/laser.hpp
@@ -15,6 +15,7 @@ class Laser
         ~Laser();
         void Update();
         void Draw();
+        Rectangle GetRect();
         bool active;
 
     private:

--- a/space_invaders/src/mystery_ship.cpp
+++ b/space_invaders/src/mystery_ship.cpp
@@ -53,3 +53,23 @@ void MysteryShip::Spawn()
 
     alive = true;
 }
+
+Rectangle MysteryShip::GetRect()
+{
+    Rectangle rect;
+    rect.x = position.x;
+    rect.y = position.y;
+
+    if(alive)
+    {
+        rect.width = image.width;
+        rect.height = image.height;
+    }
+    else
+    {
+        rect.width = 0;
+        rect.height = 0;
+    }
+
+    return rect;
+}

--- a/space_invaders/src/mystery_ship.hpp
+++ b/space_invaders/src/mystery_ship.hpp
@@ -13,6 +13,7 @@ class MysteryShip
         void Update();
         void Draw();
         void Spawn();
+        Rectangle GetRect();
         bool alive;
 
     private:

--- a/space_invaders/src/spaceship.cpp
+++ b/space_invaders/src/spaceship.cpp
@@ -47,3 +47,14 @@ void Spaceship::FireLaser()
         lastFireTime = GetTime();
     }
 }
+
+Rectangle Spaceship::GetRect()
+{
+    Rectangle rect;
+    rect.x = position.x;
+    rect.y = position.y;
+    rect.width = image.width;
+    rect.height = image.height;
+
+    return rect;
+}

--- a/space_invaders/src/spaceship.hpp
+++ b/space_invaders/src/spaceship.hpp
@@ -14,6 +14,7 @@ class Spaceship
         void MoveLeft();
         void MoveRight();
         void FireLaser();
+        Rectangle GetRect();
 
         std::vector<Laser> lasers;
 


### PR DESCRIPTION
- Check for collisions between spaceship lasers and aliens, obstacles and mystery ship.
- Check for collisions between alien lasers and spaceship and obstacles.
- Check for collisions between aliens and obstacles and spaceship.
- All objects were given a `GetRect()` public method that returns a `Rectangle`-type value that corresponds to an imaginary rectangle surrounding the object. This is necessary since `CheckCollisionRecs()` checks for a collision between two `Rectangle` objects.